### PR TITLE
add mergequeue configs

### DIFF
--- a/.mergequeue/config.yml
+++ b/.mergequeue/config.yml
@@ -1,16 +1,40 @@
-version: 1.0.0
 merge_rules:
   labels:
     trigger: mergequeue
     skip_line: mergequeue-priority
     merge_failed: blocked
-  publish_status_check: true
+    skip_delete_branch: ""
+  update_latest: true
+  delete_branch: false
+  use_rebase: false
+  publish_status_check: ready
+  status_comment:
+    publish: always
+    open_message: ""
+    queued_message: ""
+    blocked_message: ""
+  enable_comments: true
+  ci_timeout_mins: 0
+  require_all_checks_pass: false
+  require_skip_line_reason: false
+  auto_detect_stacks: false
   preconditions:
+    validations: []
+    number_of_approvals: 1
+    required_checks: []
     use_github_mergeability: true
     conversation_resolution_required: false
   merge_mode:
     type: default
+  merge_commit:
+    use_title_and_body: true
+    cut_body_before: ""
+    cut_body_after: ""
+    strip_html_comments: false
+    include_coauthors: false
   merge_strategy:
-    name: squash
-  base_branches:
-    - main
+    name: merge
+    use_separate_commits_for_stack: false
+  base_branches: []
+scenarios: []
+version: 1.1.0


### PR DESCRIPTION



<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
